### PR TITLE
Only implemente Deliverable for messages that are handled by handlers that do not change state 

### DIFF
--- a/eyg/src/home/mod.rs
+++ b/eyg/src/home/mod.rs
@@ -11,12 +11,15 @@ pub trait Deliverable<S> {
 pub type Mail<S> = Vec<Box<dyn Deliverable<S>>>;
 
 pub trait Handler<M, S> {
-    fn handle(self, message: M) -> (Mail<S>, Self);
+    type Next;
+    fn handle(self, message: M) -> (Mail<S>, Self::Next);
 }
 
 // Expose that there are Actors or no useful insights
 // Home is the same as System or Environment or Rave or Workshop or Village,
 // Workshop is interesting as Home could become skill/capability
+// If this is a Home to these kind of workers if must be possible to insert them.
+// It's up to some other step to check that if state changes stuff still works
 pub trait Home<A, M>: Sized {
     type Worker: Handler<M, Self>;
     // I don't think this is very ergonomic Rust
@@ -24,7 +27,18 @@ pub trait Home<A, M>: Sized {
     fn put(self, address: A, worker: Self::Worker) -> Self;
 }
 
-impl<A, M, S> Deliverable<S> for Envelope<A, M> where S: Home<A, M> {
+// The specification of W here indicates this only applies for when a handler does not change the state of the worker
+// impl<A, M, S, W> Deliverable<S> for Envelope<A, M>
+//     where
+//         S: Home<A, M, Worker=W>,
+//         W: Handler<M, S, Next=S::Worker>
+// {
+impl<A, M, S> Deliverable<S> for Envelope<A, M>
+    where
+        S: Home<A, M>,
+        S::Worker: Handler<M, S, Next=S::Worker>
+        // W: Handler<M, S, Next=S::Worker>
+{
     fn deliver(self: Box<Self>, system: S) -> (Mail<S>, S) {
         let Envelope{address, message} = *self;
         let (worker, system) = system.pop(&address);
@@ -46,8 +60,9 @@ mod tests {
         pub struct Counter(i32);
         // use unit as tick for countring
         impl<S> Handler<(), S> for Counter {
-            fn handle(self, _: ()) -> (Mail<S>, Self) {
-                (vec![], Counter(self.0 + 1))
+            type Next = i32;
+            fn handle(self, _: ()) -> (Mail<S>, i32) {
+                (vec![], self.0 + 1)
             }
         }
         impl Home<String, ()> for HashMap<String, Counter> {


### PR DESCRIPTION
**Note: all code is in `eyg/src/home/mod.rs` and does not depend on anything else in the repository**

Actors in a system should be able to change the type of messages they can receive, because ordering is not guaranteed they should only be able to increase the kinds of messages they can receive.

A use case for this is a webserver with a streaming endpoint. Every single connection actor must be handle to handle TCP messages; new packets, connection dropped, etc. However after handling enough data to route the request on actor might read a file, or subscribe to a data source. When this happens that actor might now receive messages that are related to File events, in addition to ongoing TCP messages.

For several reasons changing state of the Actor introduces complications, so I want to help as much as possible in cases where the `Next` type of a handler is the same as the original type. One of those cases is the Deliverable trait. I want to implement this for all Handlers where the associated Next type is Self.

See comments on the PR for more details